### PR TITLE
Add 'enable-ipv6' option to pppoe connections, needs PPPd to support

### DIFF
--- a/templates-cfg/interfaces/ethernet/node.tag/pppoe/node.tag/enable-ipv6/node.def
+++ b/templates-cfg/interfaces/ethernet/node.tag/pppoe/node.tag/enable-ipv6/node.def
@@ -1,0 +1,16 @@
+#
+# Configuration template for the .../pppoe/node.tag/enable-ipv6 parameter
+# 
+# 
+# This parameter has no "value" associated with it. If the parameter
+# exists, then ipv6 is enabled in pppd options. 
+#
+# If the parameter does not exist, then ipv6 will
+# be disabled in pppd.
+
+help: Activate IPv6 support on this connection 
+
+update:	sudo sed -i '/^+ipv6/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo +ipv6 >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^+ipv6/d' /etc/ppp/peers/pppoe$VAR(../@)

--- a/templates-cfg/interfaces/ethernet/node.tag/vif/node.tag/pppoe/node.tag/enable-ipv6/node.def
+++ b/templates-cfg/interfaces/ethernet/node.tag/vif/node.tag/pppoe/node.tag/enable-ipv6/node.def
@@ -1,0 +1,16 @@
+#
+# Configuration template for the .../pppoe/node.tag/enable-ipv6 parameter
+# 
+# 
+# This parameter has no "value" associated with it. If the parameter
+# exists, then ipv6 is enabled in pppd options. 
+#
+# If the parameter does not exist, then ipv6 will
+# be disabled in pppd.
+
+help: Activate IPv6 support on this connection 
+
+update:	sudo sed -i '/^+ipv6/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo +ipv6 >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^+ipv6/d' /etc/ppp/peers/pppoe$VAR(../@)


### PR DESCRIPTION
Add enable-ipv6 option to pppoe connections, needs pppd to support ipv6 or this option will break any pppoe connection.
See this commit :
https://github.com/kouak/ppp/commit/481c7120bd08496ae73f8ac96b277fdcf60a55cb
