### PR TITLE
Add pppoe support to bridge interface

### DIFF
--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.def
@@ -1,0 +1,92 @@
+#
+# Configuration template for interface/ethernet/node.tag/pppoe
+#
+#
+# Define a PPPOE interface.  The value of this node is the PPPOE unit
+# number.  This number must be globally unique among all PPPOE units.
+#
+
+tag:
+
+type: u32
+
+help: PPPOE unit number
+
+val_help: 0-15; Point-to-Point Protocol over Ethernet (PPPOE) unit number
+
+syntax:expression:  ((($VAR(@) >= 0) && ($VAR(@) <= 15)) ; \
+        "Only unit number must be between 0 and 15") && \
+        ( exec "NOT_OURS=`grep -s ^pty /etc/ppp/peers/pppoe$VAR(@) | grep -v -c $VAR(../@)` ; \
+                if [ $NOT_OURS -eq 0 ]; then \
+                        exit 0 ; \
+                else \
+                        exit 1 ; \
+                fi " ; \
+        "Unit number must be unique. Units already in use are: $VAR(../@@/pppoe/@@)" )
+
+
+
+#
+# At create time, we initialize a new PPP provider
+# configuration file with default values.  Other parameters will be inserted by
+# the templates for those parameters.
+#
+create:	
+	ifname=pppoe$VAR(@)
+	logfile=/var/log/vyatta/ppp_${ifname}.log
+	sudo touch $logfile
+	sudo chgrp adm $logfile
+	sudo chmod 664 $logfile
+	echo "`date`: PPP interface $ifname created" >> $logfile
+
+	sudo rm -f /etc/ppp/peers/pppoe$VAR(@)
+	sudo cp /opt/vyatta/etc/pppoe-provider-template \
+	   /etc/ppp/peers/pppoe$VAR(@) 
+        sudo sh -c "echo \#pty \\\"/usr/sbin/pppoe -m 1412 -I $VAR(../@)\\\" >> /etc/ppp/peers/pppoe$VAR(@)"
+        sudo sh -c "echo plugin rp-pppoe.so >> /etc/ppp/peers/pppoe$VAR(@)" 
+        sudo sh -c "echo $VAR(../@) >> /etc/ppp/peers/pppoe$VAR(@)"
+	sudo sh -c "echo persist >> /etc/ppp/peers/pppoe$VAR(@)"
+	sudo sh -c "echo mtu 1492  >> /etc/ppp/peers/pppoe$VAR(@)"
+	sudo sh -c "echo mru 1492  >> /etc/ppp/peers/pppoe$VAR(@)"
+        sudo sh -c "echo defaultroute  >> /etc/ppp/peers/pppoe$VAR(@)"
+	sudo sh -c "echo usepeerdns  >> /etc/ppp/peers/pppoe$VAR(@)"
+	sudo sh -c "echo ipparam pppoe$VAR(@) >> /etc/ppp/peers/pppoe$VAR(@)"
+	sudo sh -c "echo debug  >> /etc/ppp/peers/pppoe$VAR(@)"
+	sudo sh -c "echo logfile $logfile  >> /etc/ppp/peers/pppoe$VAR(@)"
+	sudo sh -c "echo ifname $ifname  >> /etc/ppp/peers/pppoe$VAR(@)"
+#
+# Delete means that this node and the tree below it has been deleted.
+# We can delete the PPP provider configuration file.  The running PPPOE
+# Daemon will be killed at "end:"
+# 
+delete:	
+	ifname=pppoe$VAR(@)
+	logfile=/var/log/vyatta/ppp_${ifname}.log
+	echo "`date`: PPP interface $ifname deleted" >> $logfile
+	sudo rm -f /etc/ppp/peers/pppoe$VAR(@)
+
+#
+# Three cases are handled here:
+#  1) A new PPPOE configuration node has just been added.  Parameters may or
+#     may not have also been added.
+#  2) Some configuration parameters of a previously existing PPPOE node
+#     have been changed.
+#  3) A previously existing PPPOE configuration node has been deleted or disabled
+# 
+# In case (1) we need to start the daemon for the first time.
+# In case (2) we need to kill and restart the daemon.
+# In case (3) we need to kill the daemon.
+#
+end:	
+	ifname=pppoe$VAR(@)
+	logfile=/var/log/vyatta/ppp_${ifname}.log
+	echo "`date`: Stopping PPP daemon for $ifname" >> $logfile
+	sudo poff pppoe$VAR(@) | logger -p debug -t pppoe$VAR(@)-template
+
+	if [ "$VAR(@/disable)" != "" ]; then
+		exit 0
+	elif [ -e /etc/ppp/peers/pppoe$VAR(@) ]; then
+		echo "`date`: Starting PPP daemon for $ifname" >> $logfile
+                ( umask 0; sudo setsid sh -c 'nohup /usr/sbin/pppd \
+			   call pppoe$VAR(@) > /tmp/pppoe$VAR(@).log 2>&1 &' )
+	fi

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/access-concentrator/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/access-concentrator/node.def
@@ -1,0 +1,18 @@
+#
+# Configuration template for the .../pppoe/node.tag/access-concentrator
+# parameter.
+#
+# If set, only connect to access concentrator with this name.
+#
+
+type: txt
+
+help: Access concentrator name (only connect to this concentrator)
+
+syntax:expression: pattern $VAR(@) "^[a-zA-Z0-9]+$" ; "Access concentrator name must be composed of uppper and lower case letters or numbers only"
+
+update:	sudo sed -r -i 's/ -C [a-zA-Z0-9]+//' /etc/ppp/peers/pppoe$VAR(../@)
+	sudo sed -i 's+/usr/sbin/pppoe+/usr/sbin/pppoe -C $VAR(@)+' /etc/ppp/peers/pppoe$VAR(../@)
+
+delete:	sudo sed -r -i 's/ -C [a-zA-Z0-9]+//' /etc/ppp/peers/pppoe$VAR(../@)
+

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/connect-on-demand/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/connect-on-demand/node.def
@@ -1,0 +1,30 @@
+#
+# Configuration template for the .../pppoe/node.tag/connect-on-demand parameter
+# 
+# 
+# This parameter has no "value" associated with it. If the parameter
+# exists, then "connect on demand" mode is enabled.  The link will not
+# be brought up automatically at boot time, but but will be brought up
+# when IP traffic needs to be sent on the link.  If the link goes down
+# for any reason, it will be brought back up when traffic needs to be
+# sent.
+# 
+# If the parameter does not exist, then "connect on demand" mode will
+# be disabled.  In this mode, the link will be brought up
+# automatically at boot time.  If it goes down for any reason, the
+# system will attempt to bring it back up immediately.
+# 
+# This parameter is usually used in conjunction with the idle-timeout
+# parameter, which disconnects the link after some period of time
+# without traffic.  Can only be used if remote-address is also set.
+#
+
+help: Automatic establishment of PPPOE connection when traffic is sent
+
+update:	sudo sed -i '/^demand/d' /etc/ppp/peers/pppoe$VAR(../@)
+	sudo sed -i '/^persist/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo demand >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^demand/d' /etc/ppp/peers/pppoe$VAR(../@)
+	sudo sed -i '/^persist/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo persist >> /etc/ppp/peers/pppoe$VAR(../@)"

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/default-route/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/default-route/node.def
@@ -1,0 +1,39 @@
+#
+# Configuration template for the .../pppoe/node.tag/default-route
+# parameter
+# 
+# 
+# This parameter has three possible values: "auto", "none" and 
+# "force". If the parameter value is "auto", or if the parameter 
+# itself does not exist, then ppp will automatically add a default 
+# route pointing to the endpoint of the link when the link comes up.  
+# The default route will only be added if no other default route 
+# already exists in the system. If the parameter value is "none", no 
+# default route will be added. If the parameter is set to "force", 
+# pre-existing default routes will be replaced. 
+
+type: txt
+
+help: Enable/disable default route to peer when link comes up
+
+val_help: auto; Install default route when link comes up
+val_help: none; Don't install default route when link comes up
+val_help: force; Install default route and replace pre-existing when link comes up
+
+syntax:expression: $VAR(@) in "auto","none","force" ; "Must be either auto, none or force."
+
+default: "auto"
+
+update:	sudo sed -i '/^defaultroute/d' /etc/ppp/peers/pppoe$VAR(../@)
+	if [ "$VAR(@)" = "auto" ]; then
+	        sudo sh -c "echo defaultroute >> /etc/ppp/peers/pppoe$VAR(../@)"
+	fi
+	if [ "$VAR(@)" = "force" ]; then
+			sudo sh -c "echo defaultroute >> /etc/ppp/peers/pppoe$VAR(../@)"
+			sudo sh -c "echo replacedefaultroute >> /etc/ppp/peers/pppoe$VAR(../@)"
+	fi
+#
+# If this parameter is deleted, behave as if it were set to "auto"
+#
+delete:	sudo sed -i '/^defaultroute/d' /etc/ppp/peers/pppoe$VAR(../@)
+		sudo sh -c "echo defaultroute >> /etc/ppp/peers/pppoe$VAR(../@)"

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/disable/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/disable/node.def
@@ -1,0 +1,1 @@
+help: Administratively disable a PPPoE session

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/enable-ipv6/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/enable-ipv6/node.def
@@ -1,0 +1,16 @@
+#
+# Configuration template for the .../pppoe/node.tag/enable-ipv6 parameter
+# 
+# 
+# This parameter has no "value" associated with it. If the parameter
+# exists, then ipv6 is enabled in pppd options. 
+#
+# If the parameter does not exist, then ipv6 will
+# be disabled in pppd.
+
+help: Activate IPv6 support on this connection 
+
+update:	sudo sed -i '/^+ipv6/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo +ipv6 >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^+ipv6/d' /etc/ppp/peers/pppoe$VAR(../@)

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/idle-timeout/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/idle-timeout/node.def
@@ -1,0 +1,16 @@
+#
+# Configuration template for the .../pppoe/node.tag/idle-timeout parameter
+#
+# This parameter sets the time in seconds after which an idle
+# connection will be closed. Disconnection of idle connections will not
+# be performed if this parameter is not set.
+#
+
+type: u32
+
+help: Delay (in seconds) before disconnecting idle session
+
+update:	sudo sed -i '/^idle/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo idle $VAR(@) >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^idle/d' /etc/ppp/peers/pppoe$VAR(../@)

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/ipv6/address/autoconf/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/ipv6/address/autoconf/node.def
@@ -1,0 +1,26 @@
+#
+# This is a valueless node, hence has no type associated with it.
+#
+
+help: Enable acquisition of IPv6 address using stateless autoconfig (SLAAC)
+
+update:
+	ifname=pppoe$VAR(../../../@)
+	script=/etc/ppp/ipv6-up.d/50-vyos-$ifname-autoconf
+	sudo cp /opt/vyatta/etc/ppp/templates/pppoe-autoconf.template $script
+	sudo sh -c "sed -i s:INTERFACE:$ifname:g $script"
+	sudo sh -c "chmod +x $script"
+	forwarding=`cat /proc/sys/net/ipv6/conf/pppoe$VAR(../../../@)/forwarding`
+	if [ $forwarding = 1 ]; then
+		echo "Warning: IPv6 forwarding is currently enabled."
+		echo "         IPv6 address auto-configuration will not be performed"
+		echo "         unless IPv6 forwarding is disabled."
+	fi
+	# TODO: we could implement a "force" option which would set accept_ra to 2
+	# so that users can use SLAAC with forwarding enabled.
+	# http://strugglers.net/~andy/blog/2011/09/04/linux-ipv6-router-advertisements-and-forwarding/comment-page-1/
+
+delete:
+	ifname=pppoe$VAR(../../../@)
+	script=/etc/ppp/ipv6-up.d/50-vyos-$ifname-autoconf
+	sudo rm $script

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/ipv6/address/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/ipv6/address/node.def
@@ -1,0 +1,1 @@
+help: IPv6 address configuration modes

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/local-address/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/local-address/node.def
@@ -1,0 +1,19 @@
+#
+# Configuration template for the .../pppoe/node.tag/local-address parameter
+#
+# Set the IPv4 address of the local side of the PPPOE link.
+#
+
+type: ipv4
+
+help: IPv4 address of the local end of the PPPOE link
+
+update:	sudo sed -i '/^[0-9:]/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo $VAR(@):$VAR(../remote-address/@) >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^[0-9:]/d' /etc/ppp/peers/pppoe$VAR(../@)
+	if [ ! -z "$VAR(../remote-address/@)" ]; then
+	        sudo sh -c "echo :$VAR(../remote-address/@) >> /etc/ppp/peers/pppoe$VAR(../@)"
+	fi
+
+

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/mtu/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/mtu/node.def
@@ -1,0 +1,30 @@
+#
+# Configuration template for the .../pppoe/node.tag/mtu parameter
+#
+# Set the IP layer Maximum Transmission Unit (MTU) for the PPPOE interface.
+# The value of the MRU option that we negotiate should match our MTU,
+# so we set both the mtu and mru values in the ppp config file.
+#
+
+type: u32
+
+help: Maximum Transmission Unit (MTU)
+
+syntax:expression: $VAR(@) >= 68 && $VAR(@) <= 1500; "MTU must be between 68 and 1500"
+
+val_help: u32:68-1500; Maximum Transmission Unit (MTU) in bytes
+
+default: 1492
+
+update:	sudo sed -i '/^mtu/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo mtu $VAR(@) >> /etc/ppp/peers/pppoe$VAR(../@)"
+	sudo sed -i '/^mru/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo mru $VAR(@) >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^mtu/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo mtu 1492 >> /etc/ppp/peers/pppoe$VAR(../@)"
+	sudo sed -i '/^mru/d' /etc/ppp/peers/pppoe$VAR(../@) ; \
+        sudo sh -c "echo mru 1492 >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+
+

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/name-server/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/name-server/node.def
@@ -1,0 +1,35 @@
+#
+# Configuration template for the .../pppoe/node.tag/name-server
+# parameter
+# 
+# 
+# This parameter has two possible values: "auto" and "none". If the
+# parameter value is "auto", or if the parameter itself does not
+# exist, then ppp will automatically add a default route pointing to
+# the endpoint of the link when the link comes up.  The default route
+# will only be added if no other default route already exists in the
+# system.  If the parameter value is "none", no default route will be
+# added.
+# 
+
+type: txt
+
+help: Enable/disable use of name server entries from peer
+
+val_help: auto; Use name server entries provided by peer
+val_help: none; Do not use name server entries provided by peer
+
+syntax:expression: $VAR(@) in "auto","none" ; "Must be either \"auto\" or \"none\""
+
+default: "auto"
+
+update:	sudo sed -i '/^usepeerdns/d' /etc/ppp/peers/pppoe$VAR(../@)
+	if [ "$VAR(@)" = "auto" ]; then
+	        sudo sh -c "echo usepeerdns >> /etc/ppp/peers/pppoe$VAR(../@)"
+	fi
+
+#
+# If this parameter is deleted, behave as if it were set to "auto"
+#
+delete:	sudo sed -i '/^usepeerdns/d' /etc/ppp/peers/pppoe$VAR(../@)
+	sudo sh -c "echo usepeerdns >> /etc/ppp/peers/pppoe$VAR(../@)"

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/password/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/password/node.def
@@ -1,0 +1,17 @@
+#
+# Configuration template for the .../pppoe/node.tag/password parameter
+#
+# This parameter sets the user name that will be used to authenticate
+# this node to the remote node.  Authentication protocol (PAP or CHAP)
+# is determined by the remote node.  This username will be used with
+# either protocol.
+#
+
+type: txt
+
+help: Password for authenticating local machine to PPPOE server
+
+update:	sudo sed -i '/^password/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo password \\\"$VAR(@)\\\" >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^password/d' /etc/ppp/peers/pppoe$VAR(../@)

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/remote-address/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/remote-address/node.def
@@ -1,0 +1,18 @@
+#
+# Configuration template for the .../pppoe/node.tag/remote-address parameter
+#
+# Set the IPv4 address of the remote end of the PPPOE link.
+#
+
+type: ipv4
+
+help: IPv4 address of the remote end of the PPPOE link
+
+update:	sudo sed -i '/^[0-9:]/d' /etc/ppp/peers/pppoe$VAR(../@)
+        sudo sh -c "echo $VAR(../local-address/@):$VAR(@) >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^[0-9:]/d' /etc/ppp/peers/pppoe$VAR(../@)
+	if [ -z "$VAR(../local-address/@)" ]; then
+  	      sudo sh -c "echo $VAR(../local-address/@): >> /etc/ppp/peers/pppoe$VAR(../@)"
+        fi
+

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/service-name/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/service-name/node.def
@@ -1,0 +1,19 @@
+#
+# Configuration template for the .../pppoe/node.tag/service-name
+# parameter.
+#
+# If set, only connect to access concentrator advertising this service name
+# only.
+#
+
+type: txt
+
+help: Service name (only connect to access concentrators advertising this)
+
+syntax:expression: pattern $VAR(@) "^[a-zA-Z0-9]+$" ; "Service name must be composed of uppper and lower case letters or numbers only"
+
+update:	sudo sed -r -i 's/ -S [a-zA-Z0-9]+//' /etc/ppp/peers/pppoe$VAR(../@)
+	sudo sed -i 's+/usr/sbin/pppoe+/usr/sbin/pppoe -S $VAR(@)+' /etc/ppp/peers/pppoe$VAR(../@)
+
+delete:	sudo sed -r -i 's/ -S [a-zA-Z0-9]+//' /etc/ppp/peers/pppoe$VAR(../@)
+

--- a/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/user-id/node.def
+++ b/templates-cfg/interfaces/bridge/node.tag/pppoe/node.tag/user-id/node.def
@@ -1,0 +1,17 @@
+#
+# Configuration template for the .../pppoe/node.tag/user-id parameter
+#
+# This parameter sets the user name that will be used to authenticate
+# this node to the remote node.  Authentication protocol (PAP or CHAP)
+# is determined by the remote node.  This username will be used with
+# either protocol.
+#
+
+type: txt
+
+help: Name for authenticating local machine to PPPOE server
+
+update:	sudo sed -i '/^user/d' /etc/ppp/peers/pppoe$VAR(../@)
+	sudo sh -c "echo user \\\"$VAR(@)\\\" >> /etc/ppp/peers/pppoe$VAR(../@)"
+
+delete:	sudo sed -i '/^user/d' /etc/ppp/peers/pppoe$VAR(../@)


### PR DESCRIPTION
## problem

- pppoe could only be set in ethernet
  - problem in the ipv6 /64 prefix environment(require bridge)

## changes

- support in bridge interfaces

## examples

```
# set interfaces bridge br0 pppoe 0 default-route 'none'
# set interfaces bridge br0 pppoe 0 firewall in name '****'
# set interfaces bridge br0 pppoe 0 password '****'
# set interfaces bridge br0 pppoe 0 user-id '****'
```

  