### PR TITLE
Add support for PPPoE sessions on bonding interfaces

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,8 @@ cpiop = find  . ! -regex '\(.*~\|.*\.bak\|.*\.swp\|.*\#.*\#\)' -print0 | \
 install-exec-hook:
 	mkdir -p $(DESTDIR)$(cfgdir)
 	cd templates-cfg; $(cpiop) $(DESTDIR)$(cfgdir)
+	mkdir -p $(DESTDIR)$(cfgdir)/interfaces/bonding
+	cd templates-cfg/interfaces/ethernet; $(cpiop) $(DESTDIR)$(cfgdir)/interfaces/bonding
 	mkdir -p $(DESTDIR)$(opdir)
 	cd templates-op; $(cpiop) $(DESTDIR)$(opdir)
 	mkdir -p $(DESTDIR)/etc/ppp/ip-pre-up.d

--- a/templates-cfg/interfaces/ethernet/node.tag/vif/node.tag/pppoe/node.def
+++ b/templates-cfg/interfaces/ethernet/node.tag/vif/node.tag/pppoe/node.def
@@ -70,7 +70,7 @@ delete:
 #     may not have also been added.
 #  2) Some configuration parameters of a previously existing PPPOE node
 #     have been changed.
-#  3) A previously existing PPPOE configuration node has been deleted.
+#  3) A previously existing PPPOE configuration node has been deleted or disabled
 # 
 # In case (1) we need to start the daemon for the first time.
 # In case (2) we need to kill and restart the daemon.
@@ -80,9 +80,11 @@ end:
 	ifname=pppoe$VAR(@)
 	logfile=/var/log/vyatta/ppp_${ifname}.log
 	echo "`date`: Stopping PPP daemon for $ifname" >> $logfile
-
 	sudo poff pppoe$VAR(@) | logger -p debug -t pppoe$VAR(@)-template
-	if [ -e /etc/ppp/peers/pppoe$VAR(@) ]; then
+
+	if [ "$VAR(@/disable)" != "" ]; then
+		exit 0
+	elif [ -e /etc/ppp/peers/pppoe$VAR(@) ]; then
 		echo "`date`: Starting PPP daemon for $ifname" >> $logfile
                 ( umask 0; sudo /usr/sbin/pppd call pppoe$VAR(@) > \
 		  	/tmp/pppoe$VAR(@).log 2>&1 & )

--- a/templates-cfg/interfaces/ethernet/node.tag/vif/node.tag/pppoe/node.tag/disable/node.def
+++ b/templates-cfg/interfaces/ethernet/node.tag/vif/node.tag/pppoe/node.tag/disable/node.def
@@ -1,0 +1,1 @@
+help: Administratively disable a PPPoE session


### PR DESCRIPTION
This pull request adds support for PPPoE sessions on bonding interfaces. Files are copied during the install phase (instead of keeping hard copies in the repo).
It also adds administrative disabling of a PPPoE session on a VIF.